### PR TITLE
Add benchmark, comparing Core, AssocList, IntDict, HashDict

### DIFF
--- a/benchmark/Main.elm
+++ b/benchmark/Main.elm
@@ -1,0 +1,82 @@
+module Main exposing (main)
+
+import AssocList
+import Benchmark exposing (..)
+import Benchmark.Runner as Runner
+import Dict exposing (Dict)
+import HashingContainers.HashDict as HashDict exposing (HashDict)
+import IntDict exposing (IntDict)
+import Typeclasses.Classes.Equality as Equality
+import Typeclasses.Classes.Hashing as Hashing
+
+
+main : Runner.BenchmarkProgram
+main =
+    Runner.program <|
+        describe "Key value containers"
+            [ describe "Core dict"
+                [ Benchmark.benchmark "Insert 1 1" <|
+                    \_ -> Dict.insert 1 1 itemsDict
+                , Benchmark.benchmark "Insert 5000 1" <|
+                    \_ -> Dict.insert 5000 1 itemsDict
+                , Benchmark.benchmark "Get 1" <|
+                    \_ -> Dict.get 1 itemsDict
+                , Benchmark.benchmark "Get 5000" <|
+                    \_ -> Dict.get 5000 itemsDict
+                ]
+            , describe "AssocList"
+                [ Benchmark.benchmark "Insert 1 1" <|
+                    \_ -> AssocList.insert 1 1 itemsAssocList
+                , Benchmark.benchmark "Insert 5000 1" <|
+                    \_ -> AssocList.insert 5000 1 itemsAssocList
+                , Benchmark.benchmark "Get 1" <|
+                    \_ -> AssocList.get 1 itemsAssocList
+                , Benchmark.benchmark "Get 5000" <|
+                    \_ -> AssocList.get 5000 itemsAssocList
+                ]
+            , describe "IntDict"
+                [ Benchmark.benchmark "Insert 1 1" <|
+                    \_ -> IntDict.insert 1 1 itemsIntDict
+                , Benchmark.benchmark "Insert 5000 1" <|
+                    \_ -> IntDict.insert 5000 1 itemsIntDict
+                , Benchmark.benchmark "Get 1" <|
+                    \_ -> IntDict.get 1 itemsIntDict
+                , Benchmark.benchmark "Get 5000" <|
+                    \_ -> IntDict.get 5000 itemsIntDict
+                ]
+            , describe "HashDict"
+                [ Benchmark.benchmark "Insert 1 1" <|
+                    \_ -> HashDict.insert 1 1 itemsHashDict
+                , Benchmark.benchmark "Insert 5000 1" <|
+                    \_ -> HashDict.insert 5000 1 itemsHashDict
+                , Benchmark.benchmark "Get 1" <|
+                    \_ -> HashDict.get 1 itemsHashDict
+                , Benchmark.benchmark "Get 5000" <|
+                    \_ -> HashDict.get 5000 itemsHashDict
+                ]
+            ]
+
+
+range : List ( Int, Int )
+range =
+    List.map2 Tuple.pair (List.range 1 9999) (List.range 1 9999)
+
+
+itemsDict : Dict Int Int
+itemsDict =
+    Dict.fromList range
+
+
+itemsAssocList : AssocList.Dict Int Int
+itemsAssocList =
+    AssocList.fromList range
+
+
+itemsHashDict : HashDict Int Int
+itemsHashDict =
+    HashDict.fromList Equality.int Hashing.int range
+
+
+itemsIntDict : IntDict Int
+itemsIntDict =
+    IntDict.fromList range

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,3 @@
+# Benchmarks
+
+Run `elm make Main.elm --optimize` and open index.html in your browser.

--- a/benchmark/elm.json
+++ b/benchmark/elm.json
@@ -1,0 +1,35 @@
+{
+    "type": "application",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm-community/intdict": "3.0.0",
+            "elm-explorations/benchmark": "1.0.1",
+            "nikita-volkov/typeclasses": "1.8.0",
+            "pzp1997/assoc-list": "1.0.0"
+        },
+        "indirect": {
+            "BrianHicks/elm-trend": "2.1.3",
+            "Skinney/murmur3": "2.0.8",
+            "elm/bytes": "1.0.8",
+            "elm/json": "1.1.3",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "mdgriffith/style-elements": "5.0.1",
+            "toastal/either": "3.5.2"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}


### PR DESCRIPTION
A simple benchmark comparing common Elm dictionaries.

The result varies quite a lot for each browser with Firefox being the slowest. But the overal difference between each package stays more or less the same.

Here is a screenshot of the result in Firefox 78.0.2 

![Screenshot_2020-07-26 Main](https://user-images.githubusercontent.com/18724157/88473892-1e280b80-cf22-11ea-8603-cc80463c2c72.png)

 